### PR TITLE
Add a new "info" operation to retrieve basic information about image

### DIFF
--- a/lib/plug_image_processing.ex
+++ b/lib/plug_image_processing.ex
@@ -1,4 +1,5 @@
 defmodule PlugImageProcessing do
+  alias PlugImageProcessing.Info
   alias PlugImageProcessing.Middleware
   alias PlugImageProcessing.Middlewares.SignatureKey
   alias PlugImageProcessing.Operation
@@ -6,6 +7,7 @@ defmodule PlugImageProcessing do
 
   @type image :: Vix.Vips.Image.t()
   @type config :: PlugImageProcessing.Config.t()
+  @type image_metadata :: PlugImageProcessing.ImageMetadata.t()
 
   @spec generate_url(String.t(), Enumerable.t(), atom(), map()) :: String.t()
   def generate_url(url, config, operation, query) do
@@ -70,6 +72,9 @@ defmodule PlugImageProcessing do
       Operation.process(operation, config)
     end
   end
+
+  @spec info(image()) :: {:ok, image_metadata()} | {:error, atom()}
+  def info(image), do: Info.process(%PlugImageProcessing.Operations.Info{image: image})
 
   @spec cast_operation_name(String.t(), config()) :: {:ok, String.t()} | {:error, atom()}
   def cast_operation_name(name, config) do

--- a/lib/plug_image_processing/config.ex
+++ b/lib/plug_image_processing/config.ex
@@ -15,7 +15,8 @@ defmodule PlugImageProcessing.Config do
     {"extract", Operations.ExtractArea},
     {"resize", Operations.Resize},
     {"smartcrop", Operations.Smartcrop},
-    {"pipeline", Operations.Pipeline}
+    {"pipeline", Operations.Pipeline},
+    {"info", Operations.Info}
   ]
 
   @middlewares [

--- a/lib/plug_image_processing/image_metadata.ex
+++ b/lib/plug_image_processing/image_metadata.ex
@@ -1,0 +1,11 @@
+defmodule PlugImageProcessing.ImageMetadata do
+  @derive Jason.Encoder
+  defstruct channels: nil, has_alpha: nil, height: nil, width: nil
+
+  @type t :: %__MODULE__{
+          channels: number(),
+          has_alpha: boolean(),
+          height: number(),
+          width: number()
+        }
+end

--- a/lib/plug_image_processing/info.ex
+++ b/lib/plug_image_processing/info.ex
@@ -1,0 +1,7 @@
+defprotocol PlugImageProcessing.Info do
+  @typep error :: {:error, atom()}
+  @type t :: struct()
+
+  @spec process(t()) :: {:ok, PlugImageProcessing.ImageMetadata.t()} | error()
+  def process(operation)
+end

--- a/lib/plug_image_processing/operations/info.ex
+++ b/lib/plug_image_processing/operations/info.ex
@@ -1,0 +1,17 @@
+defmodule PlugImageProcessing.Operations.Info do
+  defstruct image: nil
+
+  alias Vix.Vips.Image
+
+  defimpl PlugImageProcessing.Info do
+    def process(operation) do
+      {:ok,
+       %PlugImageProcessing.ImageMetadata{
+         channels: Image.bands(operation.image),
+         has_alpha: Image.has_alpha?(operation.image),
+         height: Image.height(operation.image),
+         width: Image.width(operation.image)
+       }}
+    end
+  end
+end

--- a/test/plug_image_processing/web_test.exs
+++ b/test/plug_image_processing/web_test.exs
@@ -144,5 +144,18 @@ defmodule PlugImageProcessing.WebTest do
       assert Image.width(image) === 20
       assert Image.height(image) === 50
     end
+
+    test "info", %{config: config} do
+      plug_opts = Web.init(config)
+      conn = conn(:get, "/imageproxy/info", %{url: "http://example.org/valid.jpg"})
+      conn = Web.call(conn, plug_opts)
+
+      image_metadata = Jason.decode!(conn.resp_body)
+
+      assert image_metadata["width"] === 512
+      assert image_metadata["height"] === 512
+      assert image_metadata["has_alpha"] === false
+      assert image_metadata["channels"] === 3
+    end
   end
 end


### PR DESCRIPTION
This PR adds a new `info` operation that retrieves basic information about the image: `width`, `height`, `has_alpha` and `channels` and returns it as a JSON object.