### PR TITLE
Fix internal error on info operation in pipeline

### DIFF
--- a/lib/plug_image_processing/operations/info.ex
+++ b/lib/plug_image_processing/operations/info.ex
@@ -3,6 +3,10 @@ defmodule PlugImageProcessing.Operations.Info do
 
   alias Vix.Vips.Image
 
+  def new(_image, _params, _config) do
+    {:error, :invalid_operation}
+  end
+
   defimpl PlugImageProcessing.Info do
     def process(operation) do
       {:ok,


### PR DESCRIPTION
We prevent the error from raising a "function PlugImageProcessing.Operations.Info.new/3 is undefined or private".