### PR TITLE
Fix the documentation for the sign parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,17 +70,17 @@ Then a request path like:
 
 will fail because the `sign` parameter is not present.
 
-**The HMAC-SHA256 hash is created by taking the URL path (including the leading /), the request parameters (alphabetically-sorted and concatenated with & into a string). The hash is then base64url-encoded.**
+**The HMAC-SHA256 hash is created by taking the URL path (excluding the leading /), the request parameters (alphabetically-sorted and concatenated with & into a string). The hash is then base64url-encoded.**
 
 ```elixir
-Base.url_encode64(:crypto.mac(:hmac, :sha256, "1234", "/resize" <> "quality=60&url=https://s3.ca-central-1.amazonaws.com/my_image.jpg&width=300"))
-# => "O8Xo9xrP0fM67PIWMIRL2hjkD_c5HzzBtRLfpo43ENY="
+Base.url_encode64(:crypto.mac(:hmac, :sha256, "1234", "resize" <> "quality=60&url=https://s3.ca-central-1.amazonaws.com/my_image.jpg&width=300"))
+# => "ku5SCH56vrsqEr-_VRDOFJHqa6AXslh3fpAelPAPoeI="
 ```
 
 Now this request will succeed!
 
 ```sh
-/imageproxy/resize?url=https://s3.ca-central-1.amazonaws.com/my_image.jpg&width=300&quality=60&sign=O8Xo9xrP0fM67PIWMIRL2hjkD_c5HzzBtRLfpo43ENY=
+/imageproxy/resize?url=https://s3.ca-central-1.amazonaws.com/my_image.jpg&width=300&quality=60&sign=ku5SCH56vrsqEr-_VRDOFJHqa6AXslh3fpAelPAPoeI=
 ```
 
 ## License

--- a/lib/plug_image_processing/middlewares/signature_key.ex
+++ b/lib/plug_image_processing/middlewares/signature_key.ex
@@ -14,6 +14,8 @@ defmodule PlugImageProcessing.Middlewares.SignatureKey do
       |> Map.drop(["sign"])
       |> URI.encode_query()
 
+    IO.inspect(url_path <> url_query)
+
     Base.url_encode64(:crypto.mac(:hmac, :sha256, config.url_signature_key, url_path <> url_query))
   end
 

--- a/lib/plug_image_processing/middlewares/signature_key.ex
+++ b/lib/plug_image_processing/middlewares/signature_key.ex
@@ -14,8 +14,6 @@ defmodule PlugImageProcessing.Middlewares.SignatureKey do
       |> Map.drop(["sign"])
       |> URI.encode_query()
 
-    IO.inspect(url_path <> url_query)
-
     Base.url_encode64(:crypto.mac(:hmac, :sha256, config.url_signature_key, url_path <> url_query))
   end
 

--- a/test/plug_image_processing/plug_image_processing_test.exs
+++ b/test/plug_image_processing/plug_image_processing_test.exs
@@ -15,5 +15,19 @@ defmodule PlugImageProcessingTest do
 
       assert url === "http://example.com/imageproxy/resize?url=http%3A%2F%2Fbucket.com%2Ftest.jpg&width=10"
     end
+
+    test "valid with signature", %{config: config} do
+      url_signature_key = "12345"
+      config = Keyword.put(config, :url_signature_key, url_signature_key)
+
+      url = PlugImageProcessing.generate_url("http://example.com", config, :resize, %{url: "http://bucket.com/test.jpg", width: 10})
+
+      assert url ===
+               "http://example.com/imageproxy/resize?url=http%3A%2F%2Fbucket.com%2Ftest.jpg&width=10&sign=#{generate_signature_from_url(url_signature_key, "resizeurl=http%3A%2F%2Fbucket.com%2Ftest.jpg&width=10")}"
+    end
+  end
+
+  defp generate_signature_from_url(url_signature_key, url) do
+    Base.url_encode64(:crypto.mac(:hmac, :sha256, url_signature_key, url))
   end
 end


### PR DESCRIPTION
Even thought the documentation says that you should include the leading "/" in practice you need to exclude it.

```elixir
  def generate_signature(url, config) do
    uri = URI.parse(url)
    url_path = uri.path
    url_path = String.trim_leading(url_path, config.path <> "/") # This is removing the leading /

    url_query =
      uri.query
      |> URI.decode_query()
      |> Enum.sort_by(fn {key, _} -> key end)
      |> Map.new()
      |> Map.drop(["sign"])
      |> URI.encode_query()

    Base.url_encode64(:crypto.mac(:hmac, :sha256, config.url_signature_key, url_path <> url_query))
  end
```